### PR TITLE
Remove odd character that was breaking link to examples

### DIFF
--- a/src/contract_implementation.md
+++ b/src/contract_implementation.md
@@ -1,7 +1,8 @@
 # Contract implementation
 
-Double dice game example
-[​https://github.com/noislabs/nois-dapp-examples](​https://github.com/noislabs/nois-dapp-examples)
+Double dice game example:
+
+[https://github.com/noislabs/nois-dapp-examples](https://github.com/noislabs/nois-dapp-examples)
 
 ---
 


### PR DESCRIPTION
Thought I'd take a moment to fix a link. Because I love you, friends.

So basically there was an odd character that got in there, and I exterminated it.

<img width="583" alt="Screen Shot 2023-05-09 at 9 11 53 AM" src="https://github.com/noislabs/docs/assets/1042667/ffddb099-0460-4561-9be1-eaeb5b412860">

Cannot WAIT to build cool stuff (like games!) with CronCat and Nois randomness.

